### PR TITLE
Setting hivclustering dependency to 1.2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def setup_package():
 
     setup(
         name='hivtrace',
-        version='0.4.1',
+        version='0.4.2',
         description='HIV-TRACE',
         author='Joel Wertheim, Sergei Pond, and Steven Weaver',
         author_email='sweaver@temple.edu',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def setup_package():
 
     setup(
         name='hivtrace',
-        version='0.4.2',
+        version='0.4.3',
         description='HIV-TRACE',
         author='Joel Wertheim, Sergei Pond, and Steven Weaver',
         author_email='sweaver@temple.edu',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def setup_package():
             'biopython-extensions >= 0.18.3',
             'hppy >= 0.9.9',
             'tornado >= 4.3',
-            'hivclustering >= 1.2.8',
+            'hivclustering == 1.2.8',
             ],
         entry_points={
             'console_scripts': [


### PR DESCRIPTION
A breaking change related to the viz was introduced to hivclustering during tool development. Setting hivclustering to 1.2.8 until the issue in hivclustering is resolved.