### PR TITLE
Dockerfile -> RHEL 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-# Docker image for an HIV-TRACE development environment
-FROM oraclelinux:8
+# Docker image for an HIV-TRACE development environment (Red Hat Universal Base Image 8.10)
+FROM redhat/ubi8:8.10
 
 # Set up environment and install dependencies
 RUN yum -y update && \
-    yum install -y bzip2-devel cmake gcc gcc-c++ gcc-toolset-10 git libcurl-devel make openssl-devel oracle-epel-release-el8 python3.11 python3.11-devel python3.11-pip wget xz-devel && \
-    echo 'source /opt/rh/gcc-toolset-10/enable' > ~/.bashrc && \
+    yum install -y bzip2-devel cmake gcc gcc-c++ gcc-toolset-12 git libcurl-devel openssl-devel python3.11 python3.11-devel python3.11-pip wget xz-devel && \
+    echo 'source /opt/rh/gcc-toolset-12/enable' > ~/.bashrc && \
     source ~/.bashrc && \
 
     # Update pip and use it to install Python packages


### PR DESCRIPTION
This PR migrates the `Dockerfile` from Oracle Linux to RHEL 8 (technically Red Hat UBI 8, which is their public Docker base image that is equivalent to their enterprise RHEL 8 image)