### PR TITLE
Attempted fix for True Append code

### DIFF
--- a/hivtrace/hivtraceviz.py
+++ b/hivtrace/hivtraceviz.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 """
 This module contains the command line interface for hivtrace.
 """

--- a/hivtrace/strip_drams.py
+++ b/hivtrace/strip_drams.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 # This PYTHON script will read in an aligned Fasta file (HIV prot/rt sequences) and remove
 # DRAM (drug resistance associated mutation) codon sites. It will output a new alignment
 # with these sites removed. It requires input/output file names along with the list of

--- a/hivtrace/true_append.py
+++ b/hivtrace/true_append.py
@@ -176,9 +176,20 @@ def run_tn93(seqs_new, seqs_old, out_dists_file, to_add, to_replace, to_keep, re
             run(tn93_command_new_old, input=old_fasta_data, stdout=out_dists_file)
             write_thread.join()
 
-def true_append(seqs_new, seqs_old, input_old_dists, output_dists, tn93_args=DEFAULT_TN93_ARGS, tn93_path=DEFAULT_TN93_PATH):
+# main True Append program
+def true_append(seqs_new=None, seqs_old=None, input_old_dists=None, output_dists=None, tn93_args=DEFAULT_TN93_ARGS, tn93_path=DEFAULT_TN93_PATH):
     print_log("Running HIV-TRACE True Append v%s" % HIVTRACE_TRUE_APPEND_VERSION)
-    print_log("Command: %s" % ' '.join(argv))
+    if seqs_new is None: # args not provided, so parse from command line
+        args = parse_args()
+        print_log("Command: %s" % ' '.join(argv))
+        print_log("Parsing user table: %s" % args.input_user_table)
+        seqs_new = parse_table(args.input_user_table)
+        print_log("Parsing old table: %s" % args.input_old_table)
+        seqs_old = parse_table(args.input_old_table)
+        output_dists = args.output_dists
+        input_old_dists = args.input_old_dists
+        tn93_args = args.tn93_args
+        tn93_path = args.tn93_path
     check_tn93_version(tn93_path)
     print_log("- Num New Sequences: %s" % len(seqs_new))
     print_log("- Num Old Sequences: %s" % (len(seqs_old)))
@@ -195,31 +206,6 @@ def true_append(seqs_new, seqs_old, input_old_dists, output_dists, tn93_args=DEF
     print_log("Calculating all new pairwise TN93 distances...")
     run_tn93(seqs_new, seqs_old, output_dists_file, to_add, to_replace, to_keep, remove_header=True, tn93_args=tn93_args, tn93_path=tn93_path)
 
-# main program
-def main():
-    print_log("Running HIV-TRACE True Append v%s" % VERSION)
-    args = parse_args()
-    print_log("Command: %s" % ' '.join(argv))
-    check_tn93_version(args.tn93_path)
-    print_log("Parsing user table: %s" % args.input_user_table)
-    seqs_new = parse_table(args.input_user_table)
-    print_log("- Num Sequences: %s" % len(seqs_new))
-    print_log("Parsing old table: %s" % args.input_old_table)
-    seqs_old = parse_table(args.input_old_table)
-    print_log("- Num Sequences: %s" % (len(seqs_old)))
-    print_log("Determining deltas between user table and old table...")
-    to_add, to_replace, to_delete, to_keep = determine_deltas(seqs_new, seqs_old)
-    print_log("- Add: %s" % len(to_add))
-    print_log("- Replace: %s" % len(to_replace))
-    print_log("- Delete: %s" % len(to_delete))
-    print_log("- Do nothing: %s" % (len(to_keep)))
-    print_log("Creating output TN93 distances CSV: %s" % args.output_dists)
-    output_dists_file = open_file(args.output_dists, 'w')
-    print_log("Copying old TN93 distances from: %s" % args.input_old_dists)
-    remove_IDs_tn93(args.input_old_dists, output_dists_file, to_keep, remove_header=False)
-    print_log("Calculating all new pairwise TN93 distances...")
-    run_tn93(seqs_new, seqs_old, output_dists_file, to_add, to_replace, to_keep, remove_header=True, tn93_args=args.tn93_args, tn93_path=args.tn93_path)
-
 # run main program
 if __name__ == "__main__":
-    main()
+    true_append() # running with default args will use argparse


### PR DESCRIPTION
The previous version of the True Append code created a temporary file in order to perform the pairwise "new vs. old" TN93 calculations. However, @stevenweaver reported the following:

> It looks good, but I'm encountering an occasional race condition with the temporary file creation [here](https://github.com/veg/hivtrace/pull/105/files#diff-e7c484aa7d59ce7c4d59453afa6b8005ecf7aed9a07cb8fbebabad35a5f0e722R157). I verified this by inserting a breakpoint one line prior to the relevant code, then continuing execution. The issue disappears when using the debugger (pdb) but reoccurs under normal execution.

This PR consists of 3 commits:

1. https://github.com/veg/hivtrace/commit/95e88233ec88832ea3eca862f623bc8676d35bbe replaces the temporary file (which is what was causing the aforementioned issue) with a [named pipe (FIFO)](https://en.wikipedia.org/wiki/Named_pipe)
    * This should also *slightly* speed up the code, as it removes unnecessary disk accesses for writing/reading the temporary file
    * However, while this update no longer uses [`tempfile.NamedTemporaryFile`](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile), it now uses [`tempfile.mkdtemp`](https://docs.python.org/3/library/tempfile.html#tempfile.mkdtemp) to create a temporary directory within which to create the named pipe, so it *might* still have the same issue as before (@stevenweaver please test it out to check)
2. https://github.com/veg/hivtrace/commit/70ebec1b37fb635839edd572bbe1e42309b8a8ef refactors the `true_append` function and removes the `main` function to reduce redundant code
    * In the original True Append script, a function called `main` was executed when the script was run from the command line, and this `main` function would (1) use [`argparse`](https://docs.python.org/3/library/argparse.html) to parse the user's command line arguments, and then (2) orchestrate the execution of the actual True Append functions
    * When the True Append script was migrated to the [`hivtrace`](https://github.com/veg/hivtrace) repository, a new function called `true_append` was created as a modified copy of `main` but which parses the relevant inputs via function arguments rather than command line arguments
    * This commit refactors `true_append` to parse the relevant True Append inputs via function arguments *if they're provided*, otherwise it will try to parse them from the command line, removing the need for a separate `main` function
3. https://github.com/veg/hivtrace/commit/4d790202c4ccf6edc614635bc97599daba7e6483 adds the Python 3 [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) to the other Python scripts in this repository, and it makes the scripts executable (`chmod a+x`)