### PR TITLE
Drop hppy from direct dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def setup_package():
         install_requires=[
             'biopython >= 1.58',
             'tornado >= 4.3',
-            'hivclustering[edgefiltering] >= 1.9.6',
+            'hivclustering[edgefiltering] >= 1.9.7',
             ],
         entry_points={
             'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,8 @@ def setup_package():
         python_requires='>=3.10',
         install_requires=[
             'biopython >= 1.58',
-            'hppy >= 0.9.9',
             'tornado >= 4.3',
-            'hivclustering[edgefiltering] >= 1.6.8',
+            'hivclustering[edgefiltering] >= 1.9.6',
             ],
         entry_points={
             'console_scripts': [


### PR DESCRIPTION
## Summary
- Remove `hppy` from `install_requires` — it is not imported anywhere in hivtrace
- `hppy` is already pulled in transitively via `hivclustering[edgefiltering]` for edge filtering support
- Paired with veg/hivclustering#57 which removed the stale `bioext` (and transitive `pysam`) from the edgefiltering extra

This should fix the Python 3.14 CI failure caused by pysam failing to build.