### PR TITLE
Update README for cawlign migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,154 +1,132 @@
-HIV-TRACE
-==========
+# HIV-TRACE
 
-HIV-TRACE is an application that identifies potential transmission
-clusters within a supplied FASTA file.
+HIV-TRACE identifies potential transmission clusters within a supplied FASTA file using pairwise [TN93](https://github.com/veg/tn93) genetic distances.
 
-# Installation
+## Installation
 
-## System Dependencies
+### Prerequisites
 
-* gcc >= 6.0.0
-* python3 >= 3.9
-* tn93 >= 1.0.6
+- Python >= 3.10
+- [tn93](https://github.com/veg/tn93) >= 1.0.6
+- [cawlign](https://github.com/veg/cawlign) >= 1.0.3 (unless using `--skip-alignment`)
 
-HIV-TRACE requires [tn93](https://github.com/veg/tn93) be installed and python3.
+### pip
 
-## Install using pip
-
-```
-pip3 install biopython
-pip3 install numpy
-pip3 install scipy
-pip3 install cython
-pip3 install hivtrace
+```bash
+pip install hivtrace
 ```
 
-Tested with Python `3.9.*`, `3.11`.
+## Quick Start
 
-# Example Usage
+```bash
+hivtrace -i INPUT.FASTA -a resolve -r HXB2_prrt -t .015 -m 500 -g .05 -c
+```
 
-`hivtrace -i ./INPUT.FASTA -a resolve -r HXB2_prrt -t .015 -m 500 -g .05 -c`
+## Options
 
-# Options Summary
+### `-i, --input` (required)
 
-## -i --input
+FASTA file with nucleotide sequences. Sequence names may include munged attributes, e.g. `ISOLATE_XYZ|2005|SAN DIEGO|MSM`.
 
-A FASTA file, with **nucleotide** sequences to be analyzed. Each sequence will
-be aligned to the chosen reference sequence prior to network inference.
-Sequence names may include munged attributes, 
-e.g. ISOLATE_XYZ|2005|SAN DIEGO|MSM
+### `-a, --ambiguities` (required)
 
-## -a --ambiguities
+Strategy for handling ambiguous nucleotides. See the [MBE paper](http://mbe.oxfordjournals.org/content/22/5/1208.short) for details.
 
-Handle ambiguious nucleotides using one of the following specified strategies.
+| Option    | Description                                                     |
+|-----------|-----------------------------------------------------------------|
+| `resolve` | Count any resolutions that match as a perfect match             |
+| `average` | Average all possible resolutions                                |
+| `skip`    | Skip all positions with ambiguities                             |
+| `gapmm`   | Count character-gap positions as 4-way mismatches, else average |
 
-| Option    | Description                                                                  |
-| --------- | --------------                                                               |
-| resolve   | count any resolutions that match as a perfect match                          |
-| average   | average all possible resolutions                                             |
-| skip      | skip all positions with ambiguities                                          |
-| gapmm     | count character-gap positions as 4-way mismatches, otherwise same as average |
+### `-r, --reference` (required)
 
-For more details, please see the the [MBE paper](http://mbe.oxfordjournals.org/content/22/5/1208.short).
+Reference sequence for alignment. Built-in options:
 
-## -r --reference
+| Option         | Region                          |
+|----------------|---------------------------------|
+| `HXB2_prrt`   | Protease + RT                   |
+| `NL4-3_prrt`  | Protease + RT (NL4-3)           |
+| `HXB2_pol`    | Protease + RT + Integrase       |
+| `HXB2_pr`     | Protease                        |
+| `HXB2_rt`     | Reverse Transcriptase           |
+| `HXB2_int`    | Integrase                       |
+| `HXB2_gag`    | Gag                             |
+| `HXB2_env`    | Envelope                        |
+| `HXB2_nef`    | Nef                             |
+| `HXB2_vif`    | Vif                             |
+| `HXB2_vpr`    | Vpr                             |
+| `HXB2_vpu`    | Vpu                             |
+| `HXB2_tat`    | Tat                             |
+| `HXB2_rev`    | Rev                             |
 
-The sequence that will be used to align all provided sequences to. It is assumed that
-the input sequences are in fact homologous to the reference and do not have too
-much indel variation.
+Or provide a path to a custom reference FASTA file. See [HIV-1 genome landmarks](http://www.hiv.lanl.gov/content/sequence/HIV/MAP/landmark.html) for reference.
 
-| Option               | Description                                                                                  |
-| ---------            | --------------                                                                               |
-| HXB2_vif             | Viral Infectivity Factor                                                                     |
-| HXB2_vpu             | Viral Protein U                                                                              |
-| HXB2_int             |                                                                                              |
-| HXB2_vpr             | Viral Protein R                                                                              |
-| HXB2_pr              |                                                                                              |
-| HXB2_pol             | The genomic region encoding the viral enzymes protease, reverse transcriptase, and integrase |
-| HXB2_tat             | Transactivator of HIV gene expression                                                        |
-| HXB2_rt              |                                                                                              |
-| NL4-3_prrt           |                                                                                              |
-| HXB2_prrt            |                                                                                              |
-| HXB2_nef             | 27-kd myristoylated protein produced by an ORF located at the 3' end of primate lentiviruses |
-| HXB2_gag             | The genomic region encoding the capsid proteins (group specific antigens)                    |
-| HXB2_env             | Viral glycoproteins produced as a precursor (gp160)                                          |
-| HXB2_rev             | The second necessary regulatory factor for HIV expression                                    |
-| Path/to/FASTA/file   | Path to a custom reference file                                                              |
+### `-t, --threshold` (required)
 
-Please reference the [landmarks of the HIV-1 genome](http://www.hiv.lanl.gov/content/sequence/HIV/MAP/landmark.html) if the presets seem foreign to you.
+Maximum pairwise TN93 distance for two sequences to be connected by an edge.
 
+### `-m, --minoverlap` (required)
 
-## -t --threshold
+Minimum number of overlapping non-gap characters required for distance calculation. Aim for at least `2 / threshold` aligned characters.
 
-Two sequences will be connected with a putative link (subject to filtering, see
-below), if and only if their pairwise distance does not exceed this threshold.
+### `-g, --fraction` (required)
 
-## -m --minoverlap
+Maximum ambiguity fraction (0–1) for the `resolve` strategy. Sequences exceeding this fraction fall back to `average`.
 
-Only sequences who overlap by at least this many non-gap characters will be
-included in distance calculations. Be sure to adjust this based on the length
-of the input sequences. You should aim to have at least 2/(distance threshold)
-aligned characters.
+### `-u, --curate`
 
-## -g --fraction
+Screen for contaminants.
 
-Affects _only_ the **Resolve** option for handling ambiguities.
-Any sequence with no more than the selected proportion [0 - 1] will have its
-ambiguities resolved (if possible), and ambiguities in sequences with higher
-fractions of them will be averaged. This mitigates spurious linkages due to
-highly ambiguous sequences.
+| Option       | Description                                            |
+|--------------|--------------------------------------------------------|
+| `remove`     | Remove spurious edges from the network                 |
+| `report`     | Flag sequences sharing a cluster with the reference    |
+| `separately` | Flag sequences via secondary tn93 run                  |
+| `none`       | Do nothing                                             |
 
-## -u --curate
+### `-f, --filter`
 
-Screen for contaminants by marking or removing sequences that cluster with any of the contaminant IDs.
+Phylogenetic test of conditional independence to remove spurious transitive connections (A→B→C appearing as triangles).
 
-| Option     | Description                                                     |
-| ---------  | --------------                                                  |
-| remove     | Remove spurious edges from the inferred network                 |
-| report     | Flag all sequences sharing a cluster with the reference         |
-| separately | Flag all sequences and report them via secondary tn93 command   |
-| none       | Do nothing                                                      |
+| Option   | Description                          |
+|----------|--------------------------------------|
+| `remove` | Remove spurious transitive edges     |
+| `report` | Report spurious transitive edges     |
 
+### `-s, --strip_drams`
 
+Mask drug resistance-associated mutation (DRAM) codon sites.
 
-## -f --filter
+| Option    | Description                                                                                                          |
+|-----------|----------------------------------------------------------------------------------------------------------------------|
+| `lewis`   | Sites from [Lewis et al](http://journals.plos.org/plosmedicine/article?id=10.1371/journal.pmed.0050050)              |
+| `wheeler` | Sites from [Wheeler et al](http://www.ncbi.nlm.nih.gov/pubmed/20395786)                                             |
 
-Use a phylogenetic test of conditional independence on each triangle in the
-network to remove spurious _transitive_ connections which make
-A->B->C chains look like A-B-C triangles. 
+### `-c, --compare`
 
-| Option     | Description                                                     |
-| ---------  | --------------                                                  |
-| remove     | reports supurious _transitive_ connections                      |
-| report     | removes supurious _transitive_ connections                      |
+Compare sequences to public sequences from the [Los Alamos HIV Sequence Database](http://hiv.lanl.gov).
 
+### `--skip-alignment`
 
-## -s --strip_drams
+Use input sequences as-is (assumes pre-aligned). Incompatible with `--compare`.
 
-Masks known DRAMs (Drug Resistance-Associated Mutation) positions from provided sequences.
+### `--cawlign`
 
-| Option    | Description                                                                                                                                      |
-| --------- | --------------                                                                                                                                   |
-| lewis     | Mask (with ---) the list of codon sites defined in [Lewis et al](http://journals.plos.org/plosmedicine/article?id=10.1371/journal.pmed.0050050). |
-| wheeler   | Mask (with ---) the list of codon sites defined in [Wheeler et al](http://www.ncbi.nlm.nih.gov/pubmed/20395786).                                 |
+Path to [cawlign](https://github.com/veg/cawlign) executable (default: `cawlign` in PATH).
 
- 
-## -c --compare
+### `--score-matrix`
 
-Compare uploaded sequences to all public sequences.
-Retrieved periodically from the [Los Alamos HIV Sequence Database](http://hiv.lanl.gov)
+Score matrix for alignment (default: `HIV_BETWEEN_F`).
 
-## --skip-alignment
+### `-o, --output`
 
-Skip the alignment step and use the input sequences as-is. This option assumes that the input sequences are already aligned.
+Output filename. Defaults to `<input>.results.json`.
 
-**Note:** This option is incompatible with `--compare` (comparison to LANL database), as pre-aligned sequences cannot be compared to the public database.
+## Viewing Results
 
-## -o --output
-Specify output filename. If no output filename is provided, then the output filename will be <input_filename>.results.json
+```bash
+hivtrace_viz results.json
+```
 
-
-# Viewing JSON files
-You can either use the command `hivtrace_viz <path_to_json_file>` or visit `https://veg.github.io/hivtrace-viz/` and click Load File.
-
+Or visit [hivtrace-viz](https://veg.github.io/hivtrace-viz/) and click **Load File**.


### PR DESCRIPTION
## Summary
- Update prerequisites to reflect Python >= 3.10 and cawlign (replacing bealign)
- Simplify install instructions to just `pip install hivtrace`
- Add missing `--cawlign` and `--score-matrix` CLI options
- Clean up reference table and fix swapped filter descriptions